### PR TITLE
Fix some image path in devices documentation

### DIFF
--- a/docs/devices/CompatibilityList.html
+++ b/docs/devices/CompatibilityList.html
@@ -144,15 +144,15 @@
 <p>, , 8-digital-output</p>
 <a class="reference internal image-reference" href="../_images/node_8-digital-output.png"><img alt="../_images/node_8-digital-output.png" src="../_images/node_8-digital-output.png" style="width: 200px;" /></a>
 <p>Orvibo, CM10ZW, Orvibo multi-functional relay</p>
-<a class="reference internal image-reference" href="devices/images/node_Orvibo-CM10ZW.png"><img alt="devices/images/node_Orvibo-CM10ZW.png" src="devices/images/node_Orvibo-CM10ZW.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Orvibo-CM10ZW.png"><img alt="../_images/node_Orvibo-CM10ZW.png" src="../_images/node_Orvibo-CM10ZW.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Orvibo, ST30, Orvibo ST30 temperature/humidity sensor</p>
-<a class="reference internal image-reference" href="devices/images/node_Orvibo-ST30.png"><img alt="devices/images/node_Orvibo-ST30.png" src="devices/images/node_Orvibo-ST30.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Orvibo-ST30.png"><img alt="../_images/node_Orvibo-ST30.png" src="../_images/node_Orvibo-ST30.png" style="width: 200px;" /></a>
 <p>, , Ampoule Ledvance Classic E27 Tunable White</p>
 <a class="reference internal image-reference" href="../_images/node_A60TWZ3.png"><img alt="../_images/node_A60TWZ3.png" src="../_images/node_A60TWZ3.png" style="width: 200px;" /></a>
 <p>Acova, Alcantara 2, Acova Alcantara 2</p>
-<a class="reference internal image-reference" href="devices/images/node_Acova-Alcantara2.png"><img alt="devices/images/node_Acova-Alcantara2.png" src="devices/images/node_Acova-Alcantara2.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Acova-Alcantara2.png"><img alt="../_images/node_Acova-Alcantara2.png" src="../_images/node_Acova-Alcantara2.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Sonoff, BASICZBR3, Sonoff BASICZBR3 DIY smart switch</p>
@@ -166,7 +166,7 @@
 <p>, , Heiman HS1CA (détecteur de monoxyde de carbone)</p>
 <a class="reference internal image-reference" href="../_images/node_COSensor-EM.png"><img alt="../_images/node_COSensor-EM.png" src="../_images/node_COSensor-EM.png" style="width: 200px;" /></a>
 <p>, , Legrand Cable Outlet 3000W</p>
-<a class="reference internal image-reference" href="devices/images/node_Legrand-Cableoutlet.png"><img alt="devices/images/node_Legrand-Cableoutlet.png" src="devices/images/node_Legrand-Cableoutlet.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Legrand-Cableoutlet.png"><img alt="../_images/node_Legrand-Cableoutlet.png" src="../_images/node_Legrand-Cableoutlet.png" style="width: 200px;" /></a>
 <p>, , Classic A60 RGB W</p>
 <a class="reference internal image-reference" href="../_images/node_OSRAMClassicA60RGBW.png"><img alt="../_images/node_OSRAMClassicA60RGBW.png" src="../_images/node_OSRAMClassicA60RGBW.png" style="width: 200px;" /></a>
 <p>, , OSRAM Classic A60 W clear - LIGHTIFY - 2</p>
@@ -178,7 +178,7 @@
 <p>, , Legrand Prise Connected Outlet Mural 220V avec Neutre</p>
 <a class="reference internal image-reference" href="../_images/node_Connectedoutlet.png"><img alt="../_images/node_Connectedoutlet.png" src="../_images/node_Connectedoutlet.png" style="width: 200px;" /></a>
 <p>Niko, , Niko connected outlet socket</p>
-<a class="reference internal image-reference" href="devices/images/node_Niko-ConnectedSocketOutlet.png"><img alt="devices/images/node_Niko-ConnectedSocketOutlet.png" src="devices/images/node_Niko-ConnectedSocketOutlet.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Niko-ConnectedSocketOutlet.png"><img alt="../_images/node_Niko-ConnectedSocketOutlet.png" src="../_images/node_Niko-ConnectedSocketOutlet.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Legrand, 20AX, Legrand Contactor 20AX</p>
@@ -190,7 +190,7 @@
 <p>Sonoff, SNZB-04, Sonoff SNZB-04 Wireless Door/Window Sensor</p>
 <a class="reference internal image-reference" href="../_images/node_SNZB-04.png"><img alt="../_images/node_SNZB-04.png" src="../_images/node_SNZB-04.png" style="width: 200px;" /></a>
 <p>Iolloi, ID-EU20FWB4L, Iolloi flush-mounted dimmer switch 5-250 W, trailing edge dimmer</p>
-<a class="reference internal image-reference" href="devices/images/node_Iolloi-ID-EU20FWB4L.png"><img alt="devices/images/node_Iolloi-ID-EU20FWB4L.png" src="devices/images/node_Iolloi-ID-EU20FWB4L.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Iolloi-ID-EU20FWB4L.png"><img alt="../_images/node_Iolloi-ID-EU20FWB4L.png" src="../_images/node_Iolloi-ID-EU20FWB4L.png" style="width: 200px;" /></a>
 <p>, , Legrand Dimmer Switch w/o neutral</p>
 <a class="reference internal image-reference" href="../_images/node_Dimmerswitchwoneutral.png"><img alt="../_images/node_Dimmerswitchwoneutral.png" src="../_images/node_Dimmerswitchwoneutral.png" style="width: 200px;" /></a>
 <p>, , IKEA Panneau TRADFRI FLOALT White Spectre 2800 lm</p>
@@ -230,7 +230,7 @@
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Gledopto, GL-SD-001, Gledopto GL-SD-001 AC dimmer</p>
-<a class="reference internal image-reference" href="devices/images/node_Gledopto-GL-SD-001.png"><img alt="devices/images/node_Gledopto-GL-SD-001.png" src="devices/images/node_Gledopto-GL-SD-001.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Gledopto-GL-SD-001.png"><img alt="../_images/node_Gledopto-GL-SD-001.png" src="../_images/node_Gledopto-GL-SD-001.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , GLEDOPTO</p>
@@ -300,11 +300,11 @@
 <p>, , ZigBee On Off Controller</p>
 <a class="reference internal image-reference" href="../_images/node_Lamp_01.png"><img alt="../_images/node_Lamp_01.png" src="../_images/node_Lamp_01.png" style="width: 200px;" /></a>
 <p>Osram, AC0251100NJ, Osram Smart+ Switch Mini</p>
-<a class="reference internal image-reference" href="devices/images/node_Osram-SwitchMini.png"><img alt="devices/images/node_Osram-SwitchMini.png" src="devices/images/node_Osram-SwitchMini.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Osram-SwitchMini.png"><img alt="../_images/node_Osram-SwitchMini.png" src="../_images/node_Osram-SwitchMini.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Profalux, MAI-ZTS, Profalux gen 2 remote control</p>
-<a class="reference internal image-reference" href="devices/images/node_ProfaluxTelecommande.png"><img alt="devices/images/node_ProfaluxTelecommande.png" src="devices/images/node_ProfaluxTelecommande.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_ProfaluxTelecommande.png"><img alt="../_images/node_ProfaluxTelecommande.png" src="../_images/node_ProfaluxTelecommande.png" style="width: 200px;" /></a>
 <p>Profalux, Volets 2nd gen, Profalux volet gen 2</p>
 <a class="reference internal image-reference" href="../_images/node_voletProFalux.png"><img alt="../_images/node_voletProFalux.png" src="../_images/node_voletProFalux.png" style="width: 200px;" /></a>
 <p>, , MR16 TW OSRAM OSRAM Spot LED dimmable connecté Smart</p>
@@ -334,11 +334,11 @@
 <p>, , Ampoule Innr spectre blanc 2200K-2700K E27</p>
 <a class="reference internal image-reference" href="../_images/node_RB175W.png"><img alt="../_images/node_RB175W.png" src="../_images/node_RB175W.png" style="width: 200px;" /></a>
 <p>Innr, RB285C, Innr RB285C RGBW bulb colour E27</p>
-<a class="reference internal image-reference" href="devices/images/node_RB285C.png"><img alt="devices/images/node_RB285C.png" src="devices/images/node_RB285C.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_RB285C.png"><img alt="../_images/node_RB285C.png" src="../_images/node_RB285C.png" style="width: 200px;" /></a>
 <p>, , Télécommande RC110 INNR</p>
 <a class="reference internal image-reference" href="../_images/node_RC110.png"><img alt="../_images/node_RC110.png" src="../_images/node_RC110.png" style="width: 200px;" /></a>
 <p>Philips/Signify, 929003017102, Hue wall switch module</p>
-<a class="reference internal image-reference" href="devices/images/node_PhilipsSignify-RDM001.png"><img alt="devices/images/node_PhilipsSignify-RDM001.png" src="devices/images/node_PhilipsSignify-RDM001.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_PhilipsSignify-RDM001.png"><img alt="../_images/node_PhilipsSignify-RDM001.png" src="../_images/node_PhilipsSignify-RDM001.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , Ampoule Innr Edison RF263 Vintage E27</p>
@@ -348,13 +348,13 @@
 <p>, , Tuya NEO RH3001 door sensor</p>
 <a class="reference internal image-reference" href="../_images/node_RH3001.png"><img alt="../_images/node_RH3001.png" src="../_images/node_RH3001.png" style="width: 200px;" /></a>
 <p>Tuya, RH3040, Tuya RH3040 PIR sensor</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-RH3040.png"><img alt="devices/images/node_Tuya-RH3040.png" src="devices/images/node_Tuya-RH3040.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-RH3040.png"><img alt="../_images/node_Tuya-RH3040.png" src="../_images/node_Tuya-RH3040.png" style="width: 200px;" /></a>
 <p>Philips, RWL021, Hue Dimmer Switch RWL021</p>
 <a class="reference internal image-reference" href="../_images/node_RWL021.png"><img alt="../_images/node_RWL021.png" src="../_images/node_RWL021.png" style="width: 200px;" /></a>
 <p>, , Legrand Télécommande Depart Arrivée</p>
 <a class="reference internal image-reference" href="../_images/node_LegrandRemoteSwitch.png"><img alt="../_images/node_LegrandRemoteSwitch.png" src="../_images/node_LegrandRemoteSwitch.png" style="width: 200px;" /></a>
 <p>Sonoff, S26R2ZB, Sonoff S26R2ZB Smart Plug</p>
-<a class="reference internal image-reference" href="devices/images/node_Sonoff-S26R2ZB.png"><img alt="devices/images/node_Sonoff-S26R2ZB.png" src="devices/images/node_Sonoff-S26R2ZB.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Sonoff-S26R2ZB.png"><img alt="../_images/node_Sonoff-S26R2ZB.png" src="../_images/node_Sonoff-S26R2ZB.png" style="width: 200px;" /></a>
 <p>, , ZigBee On Off Controller</p>
 <a class="reference internal image-reference" href="../_images/node_SA-003-Zigbee.png"><img alt="../_images/node_SA-003-Zigbee.png" src="../_images/node_SA-003-Zigbee.png" style="width: 200px;" /></a>
 <p>, , SM309</p>
@@ -366,11 +366,11 @@
 <p>, , SP220 Innr</p>
 <a class="reference internal image-reference" href="../_images/node_SP220.png"><img alt="../_images/node_SP220.png" src="../_images/node_SP220.png" style="width: 200px;" /></a>
 <p>Frient, SPLZB-131, Frient Smart Plug Mini Type F</p>
-<a class="reference internal image-reference" href="devices/images/node_Delveco-SPLZB-132.png"><img alt="devices/images/node_Delveco-SPLZB-132.png" src="devices/images/node_Delveco-SPLZB-132.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Delveco-SPLZB-132.png"><img alt="../_images/node_Delveco-SPLZB-132.png" src="../_images/node_Delveco-SPLZB-132.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Frient, SPLZB-132, Frient Smart Plug Mini Type E (French)</p>
-<a class="reference internal image-reference" href="devices/images/node_Delveco-SPLZB-132.png"><img alt="devices/images/node_Delveco-SPLZB-132.png" src="devices/images/node_Delveco-SPLZB-132.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Delveco-SPLZB-132.png"><img alt="../_images/node_Delveco-SPLZB-132.png" src="../_images/node_Delveco-SPLZB-132.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , Eurotronic Spirit</p>
@@ -404,7 +404,7 @@
 <p>Ikea, , TRADFRI bulb E14 White Spectre 470lm</p>
 <a class="reference internal image-reference" href="../_images/node_TRADFRIbulbE14WS470lm.png"><img alt="../_images/node_TRADFRIbulbE14WS470lm.png" src="../_images/node_TRADFRIbulbE14WS470lm.png" style="width: 200px;" /></a>
 <p>Ikea, LED1949C5, Ikea E14 470lm candle bulb</p>
-<a class="reference internal image-reference" href="devices/images/node_Ikea-BulbE14CandleWhite.png"><img alt="devices/images/node_Ikea-BulbE14CandleWhite.png" src="devices/images/node_Ikea-BulbE14CandleWhite.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Ikea-BulbE14CandleWhite.png"><img alt="../_images/node_Ikea-BulbE14CandleWhite.png" src="../_images/node_Ikea-BulbE14CandleWhite.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Ikea, , TRADFRI bulb E14 White Spectre opal 400lm</p>
@@ -472,11 +472,11 @@
 <p>, , IKEA TRADFRI Dimmer Jaune</p>
 <a class="reference internal image-reference" href="../_images/node_IkeaTradfriDimmer.png"><img alt="../_images/node_IkeaTradfriDimmer.png" src="../_images/node_IkeaTradfriDimmer.png" style="width: 200px;" /></a>
 <p>Profalux, Télecommande, Profalux télécommande</p>
-<a class="reference internal image-reference" href="devices/images/node_ProfaluxTelecommande.png"><img alt="devices/images/node_ProfaluxTelecommande.png" src="devices/images/node_ProfaluxTelecommande.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_ProfaluxTelecommande.png"><img alt="../_images/node_ProfaluxTelecommande.png" src="../_images/node_ProfaluxTelecommande.png" style="width: 200px;" /></a>
 <p>, , Zemismart 1 boutons</p>
 <a class="reference internal image-reference" href="../_images/node_TS0001.png"><img alt="../_images/node_TS0001.png" src="../_images/node_TS0001.png" style="width: 200px;" /></a>
 <p>Girier, JR-ZDS01, Girier DIY Smart Switch</p>
-<a class="reference internal image-reference" href="devices/images/node_JR-ZDS01.png"><img alt="devices/images/node_JR-ZDS01.png" src="devices/images/node_JR-ZDS01.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_JR-ZDS01.png"><img alt="../_images/node_JR-ZDS01.png" src="../_images/node_JR-ZDS01.png" style="width: 200px;" /></a>
 <p>, , Zemismart 2 boutons</p>
 <a class="reference internal image-reference" href="../_images/node_TS0002.png"><img alt="../_images/node_TS0002.png" src="../_images/node_TS0002.png" style="width: 200px;" /></a>
 <p>, , Zemismart 3 boutons</p>
@@ -484,7 +484,7 @@
 <p>, , Yagusmart Tuya ZigBee Smart Switch 1 Bang</p>
 <a class="reference internal image-reference" href="../_images/node_TS0011.png"><img alt="../_images/node_TS0011.png" src="../_images/node_TS0011.png" style="width: 200px;" /></a>
 <p>Avatto, Z-N-WSM01, Avatto 1 channel switch module</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-1chanSwitchModule.png"><img alt="devices/images/node_Tuya-1chanSwitchModule.png" src="devices/images/node_Tuya-1chanSwitchModule.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-1chanSwitchModule.png"><img alt="../_images/node_Tuya-1chanSwitchModule.png" src="../_images/node_Tuya-1chanSwitchModule.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , Zemismart tactile 2gang sans neutre</p>
@@ -494,7 +494,7 @@
 <p>, , Zemismart Remote 1 bouton sur pile</p>
 <a class="reference internal image-reference" href="../_images/node_TS0041.png"><img alt="../_images/node_TS0041.png" src="../_images/node_TS0041.png" style="width: 200px;" /></a>
 <p>Zemismart, YC-ZS-LO3C-A, Zemismart 2 buttons wireless switch</p>
-<a class="reference internal image-reference" href="devices/images/node_Zemismart-2ButtonsSwitch.png"><img alt="devices/images/node_Zemismart-2ButtonsSwitch.png" src="devices/images/node_Zemismart-2ButtonsSwitch.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Zemismart-2ButtonsSwitch.png"><img alt="../_images/node_Zemismart-2ButtonsSwitch.png" src="../_images/node_Zemismart-2ButtonsSwitch.png" style="width: 200px;" /></a>
 <p>, , Switch Zemismart TS0043 3 boutons sur piles</p>
 <a class="reference internal image-reference" href="../_images/node_TS0043.png"><img alt="../_images/node_TS0043.png" src="../_images/node_TS0043.png" style="width: 200px;" /></a>
 <p>LoraTap, SS600ZB, LoraTap Zigbee 3 gang remote</p>
@@ -502,11 +502,11 @@
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Tuya, TS0044, Tuya 4 buttons Zigbee scene switch</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-TS0044.png"><img alt="devices/images/node_Tuya-TS0044.png" src="devices/images/node_Tuya-TS0044.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-TS0044.png"><img alt="../_images/node_Tuya-TS0044.png" src="../_images/node_Tuya-TS0044.png" style="width: 200px;" /></a>
 <p>Tuya, , Tuya 4 buttons Zigbee scene switch</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya4ButtonsSceneSwitch.png"><img alt="devices/images/node_Tuya4ButtonsSceneSwitch.png" src="devices/images/node_Tuya4ButtonsSceneSwitch.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya4ButtonsSceneSwitch.png"><img alt="../_images/node_Tuya4ButtonsSceneSwitch.png" src="../_images/node_Tuya4ButtonsSceneSwitch.png" style="width: 200px;" /></a>
 <p>Tuya, ESW-0ZAA-EU, Tuya 4 buttons scene switch</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya4ButtonsSwitch.png"><img alt="devices/images/node_Tuya4ButtonsSwitch.png" src="devices/images/node_Tuya4ButtonsSwitch.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya4ButtonsSwitch.png"><img alt="../_images/node_Tuya4ButtonsSwitch.png" src="../_images/node_Tuya4ButtonsSwitch.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , Vanne Zigbee</p>
@@ -518,11 +518,11 @@
 <p>, , Yagusmart Tuya ZigBee Smart Switch</p>
 <a class="reference internal image-reference" href="../_images/node_TS0121.png"><img alt="../_images/node_TS0121.png" src="../_images/node_TS0121.png" style="width: 200px;" /></a>
 <p>Sixwgh, WH025, Sixwgh WH025 plug</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-TS011F.png"><img alt="devices/images/node_Tuya-TS011F.png" src="devices/images/node_Tuya-TS011F.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-TS011F.png"><img alt="../_images/node_Tuya-TS011F.png" src="../_images/node_Tuya-TS011F.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>UseeLink, SM-SO306, 4 gang switch, with USB</p>
-<a class="reference internal image-reference" href="devices/images/node_UseeLink-SM-SO306.png"><img alt="devices/images/node_UseeLink-SM-SO306.png" src="devices/images/node_UseeLink-SM-SO306.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_UseeLink-SM-SO306.png"><img alt="../_images/node_UseeLink-SM-SO306.png" src="../_images/node_UseeLink-SM-SO306.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Blitzwolf, SHP15, Blitzwolf SHP15</p>
@@ -532,7 +532,7 @@
 <p>Silvercrest, HG06338-FR, Silvercrest power strip USB SPSZ 3 A1</p>
 <a class="reference internal image-reference" href="../_images/node_TS011F__TZ3000_vzopcetz.png"><img alt="../_images/node_TS011F__TZ3000_vzopcetz.png" src="../_images/node_TS011F__TZ3000_vzopcetz.png" style="width: 200px;" /></a>
 <p>Silvercrest, HG06337-FR, SAPZ-1-A1 connected plug</p>
-<a class="reference internal image-reference" href="devices/images/node_Silvercrest-HG06337-FR.png"><img alt="devices/images/node_Silvercrest-HG06337-FR.png" src="devices/images/node_Silvercrest-HG06337-FR.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Silvercrest-HG06337-FR.png"><img alt="../_images/node_Silvercrest-HG06337-FR.png" src="../_images/node_Silvercrest-HG06337-FR.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , TS0121</p>
@@ -540,33 +540,33 @@
 <p>, , Prise Tuya</p>
 <a class="reference internal image-reference" href="../_images/node_defaultUnknown.png"><img alt="../_images/node_defaultUnknown.png" src="../_images/node_defaultUnknown.png" style="width: 200px;" /></a>
 <p>Girier, JR-ZPM01, Girier/Tuya ZigBee smart plug EU</p>
-<a class="reference internal image-reference" href="devices/images/node_JR-ZPM01.png"><img alt="devices/images/node_JR-ZPM01.png" src="devices/images/node_JR-ZPM01.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_JR-ZPM01.png"><img alt="../_images/node_JR-ZPM01.png" src="../_images/node_JR-ZPM01.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , Blitzwolf-BW-SHP13</p>
 <a class="reference internal image-reference" href="../_images/node_Blitzwolf-BW-SHP13.png"><img alt="../_images/node_Blitzwolf-BW-SHP13.png" src="../_images/node_Blitzwolf-BW-SHP13.png" style="width: 200px;" /></a>
 <p>Tuya, Generic smart socket, Tuya smart socket</p>
-<a class="reference internal image-reference" href="devices/images/node_TuyaSmartSocket.png"><img alt="devices/images/node_TuyaSmartSocket.png" src="devices/images/node_TuyaSmartSocket.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_TuyaSmartSocket.png"><img alt="../_images/node_TuyaSmartSocket.png" src="../_images/node_TuyaSmartSocket.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , Wireless Temperature and Humidity</p>
 <a class="reference internal image-reference" href="../_images/node_TS0201.png"><img alt="../_images/node_TS0201.png" src="../_images/node_TS0201.png" style="width: 200px;" /></a>
 <p>Tuya, ZM-CG205, Tuya ZM-CG205 door sensor</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-DoorSensor-ZM-CG205.png"><img alt="devices/images/node_Tuya-DoorSensor-ZM-CG205.png" src="devices/images/node_Tuya-DoorSensor-ZM-CG205.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-DoorSensor-ZM-CG205.png"><img alt="../_images/node_Tuya-DoorSensor-ZM-CG205.png" src="../_images/node_Tuya-DoorSensor-ZM-CG205.png" style="width: 200px;" /></a>
 <p>Zemismart, ZXZDS, Zemismart door &amp; window sensor</p>
-<a class="reference internal image-reference" href="devices/images/node_Zemismart-DoorSensor.png"><img alt="devices/images/node_Zemismart-DoorSensor.png" src="devices/images/node_Zemismart-DoorSensor.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Zemismart-DoorSensor.png"><img alt="../_images/node_Zemismart-DoorSensor.png" src="../_images/node_Zemismart-DoorSensor.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Tuya, RP280, Tuya RP280 zigbee repeater</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-Repeater-RP280.png"><img alt="devices/images/node_Tuya-Repeater-RP280.png" src="devices/images/node_Tuya-Repeater-RP280.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-Repeater-RP280.png"><img alt="../_images/node_Tuya-Repeater-RP280.png" src="../_images/node_Tuya-Repeater-RP280.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Moes, ZSS-ZK-THL, Smart Brightness Thermometer</p>
-<a class="reference internal image-reference" href="devices/images/node_Moes-ZSS-ZK-THL.png"><img alt="devices/images/node_Moes-ZSS-ZK-THL.png" src="devices/images/node_Moes-ZSS-ZK-THL.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Moes-ZSS-ZK-THL.png"><img alt="../_images/node_Moes-ZSS-ZK-THL.png" src="../_images/node_Moes-ZSS-ZK-THL.png" style="width: 200px;" /></a>
 <p>, , SM-SW101-CZ</p>
 <a class="reference internal image-reference" href="../_images/node_TS0302.png"><img alt="../_images/node_TS0302.png" src="../_images/node_TS0302.png" style="width: 200px;" /></a>
 <p>Tuya, TS0501B , Tuya Single Color LED Controller</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-TS0501B-LedController.png"><img alt="devices/images/node_Tuya-TS0501B-LedController.png" src="devices/images/node_Tuya-TS0501B-LedController.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-TS0501B-LedController.png"><img alt="../_images/node_Tuya-TS0501B-LedController.png" src="../_images/node_Tuya-TS0501B-LedController.png" style="width: 200px;" /></a>
 <p>LivarnoLux, HG07878A, LivarnoLux HG07878A bulb</p>
 <a class="reference internal image-reference" href="../_images/node_FlexRGBW.png"><img alt="../_images/node_FlexRGBW.png" src="../_images/node_FlexRGBW.png" style="width: 200px;" /></a>
 <p>, ,</p>
@@ -576,11 +576,11 @@
 <p>Tuya, , Silvercrest Ruban a LED</p>
 <a class="reference internal image-reference" href="../_images/node_FlexRGBW.png"><img alt="../_images/node_FlexRGBW.png" src="../_images/node_FlexRGBW.png" style="width: 200px;" /></a>
 <p>LivarnoLux, HG06701B, LivarnoLux HG06701B applique murale</p>
-<a class="reference internal image-reference" href="devices/images/node_LivarnoLux-HG06701B.png"><img alt="devices/images/node_LivarnoLux-HG06701B.png" src="devices/images/node_LivarnoLux-HG06701B.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_LivarnoLux-HG06701B.png"><img alt="../_images/node_LivarnoLux-HG06701B.png" src="../_images/node_LivarnoLux-HG06701B.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Silvercrest, HG06106C, Silvercrest HG06106C light bulb</p>
-<a class="reference internal image-reference" href="devices/images/node_Silvercrest-HG06106C.png"><img alt="devices/images/node_Silvercrest-HG06106C.png" src="devices/images/node_Silvercrest-HG06106C.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Silvercrest-HG06106C.png"><img alt="../_images/node_Silvercrest-HG06106C.png" src="../_images/node_Silvercrest-HG06106C.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Silvercrest, , Silvercrest Ruban a LED</p>
@@ -590,33 +590,33 @@
 <p>Tuya, , Yandhi E27 Bulb</p>
 <a class="reference internal image-reference" href="../_images/node_TRADFRIbulbE27CWSopal600lm.png"><img alt="../_images/node_TRADFRIbulbE27CWSopal600lm.png" src="../_images/node_TRADFRIbulbE27CWSopal600lm.png" style="width: 200px;" /></a>
 <p>LivarnoHome, HG07834C, LivarnoHome HG07834C E27 bulb</p>
-<a class="reference internal image-reference" href="devices/images/node_Silvercrest-HG06106C.png"><img alt="devices/images/node_Silvercrest-HG06106C.png" src="devices/images/node_Silvercrest-HG06106C.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Silvercrest-HG06106C.png"><img alt="../_images/node_Silvercrest-HG06106C.png" src="../_images/node_Silvercrest-HG06106C.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Tuya, TS0505B, Tuya TS0505B GU10 color bulb</p>
-<a class="reference internal image-reference" href="devices/images/node_?.png"><img alt="devices/images/node_?.png" src="devices/images/node_?.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_?.png"><img alt="../_images/node_?.png" src="../_images/node_?.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Tuya, TV02, Tuya TV02</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-TV02.png"><img alt="devices/images/node_Tuya-TV02.png" src="devices/images/node_Tuya-TV02.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-TV02.png"><img alt="../_images/node_Tuya-TV02.png" src="../_images/node_Tuya-TV02.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Tuya, QS-zigbee-C01, Tuya QS-zigbee-C01 curtain module</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-QS-Zigbee-C01.png"><img alt="devices/images/node_Tuya-QS-Zigbee-C01.png" src="devices/images/node_Tuya-QS-Zigbee-C01.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-QS-Zigbee-C01.png"><img alt="../_images/node_Tuya-QS-Zigbee-C01.png" src="../_images/node_Tuya-QS-Zigbee-C01.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Tuya, QS-Zigbee-C01, Tuya QS-Zigbee-C01 Curtain Module</p>
-<a class="reference internal image-reference" href="devices/images/node_Tuya-QS-Zigbee-C01.png"><img alt="devices/images/node_Tuya-QS-Zigbee-C01.png" src="devices/images/node_Tuya-QS-Zigbee-C01.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Tuya-QS-Zigbee-C01.png"><img alt="../_images/node_Tuya-QS-Zigbee-C01.png" src="../_images/node_Tuya-QS-Zigbee-C01.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>dOOWifi, DWF-0205ZB-PN-2, dOOWifi window module</p>
-<a class="reference internal image-reference" href="devices/images/node_dOOWifi-DWF-0205ZB-PN.png"><img alt="devices/images/node_dOOWifi-DWF-0205ZB-PN.png" src="devices/images/node_dOOWifi-DWF-0205ZB-PN.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_dOOWifi-DWF-0205ZB-PN.png"><img alt="../_images/node_dOOWifi-DWF-0205ZB-PN.png" src="../_images/node_dOOWifi-DWF-0205ZB-PN.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , Wima Lock</p>
 <a class="reference internal image-reference" href="../_images/node_TY0A01.png"><img alt="../_images/node_TY0A01.png" src="../_images/node_TY0A01.png" style="width: 200px;" /></a>
 <p>Legrand, 16AX, Legrand 16AX Teleruptor</p>
-<a class="reference internal image-reference" href="devices/images/node_Legrand-Teleruptor.png"><img alt="devices/images/node_Legrand-Teleruptor.png" src="devices/images/node_Legrand-Teleruptor.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Legrand-Teleruptor.png"><img alt="../_images/node_Legrand-Teleruptor.png" src="../_images/node_Legrand-Teleruptor.png" style="width: 200px;" /></a>
 <p>Sonoff, SNZB-01, Sonoff SNZB-01 wireless button</p>
 <a class="reference internal image-reference" href="../_images/node_SNZB-01.png"><img alt="../_images/node_SNZB-01.png" src="../_images/node_SNZB-01.png" style="width: 200px;" /></a>
 <p>, , WS2812_light_controller</p>
@@ -626,11 +626,11 @@
 <p>, , Alarm Smart Siren M420-2Evert1.2 HS2WD-E</p>
 <a class="reference internal image-reference" href="../_images/node_HS2WD.png"><img alt="../_images/node_HS2WD.png" src="../_images/node_HS2WD.png" style="width: 200px;" /></a>
 <p>eWeLight, smart bulb, Tuya smart light GU10</p>
-<a class="reference internal image-reference" href="devices/images/node_ZB-CL01.png"><img alt="devices/images/node_ZB-CL01.png" src="devices/images/node_ZB-CL01.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_ZB-CL01.png"><img alt="../_images/node_ZB-CL01.png" src="../_images/node_ZB-CL01.png" style="width: 200px;" /></a>
 <p>, , ZB-RGBCW</p>
 <a class="reference internal image-reference" href="../_images/node_defaultUnknown.png"><img alt="../_images/node_defaultUnknown.png" src="../_images/node_defaultUnknown.png" style="width: 200px;" /></a>
 <p>eWeLink, ZB-SW01, eWeLink ZB-SW01 smart light switch</p>
-<a class="reference internal image-reference" href="devices/images/node_eWeLink-ZB-SW01.png"><img alt="devices/images/node_eWeLink-ZB-SW01.png" src="devices/images/node_eWeLink-ZB-SW01.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_eWeLink-ZB-SW01.png"><img alt="../_images/node_eWeLink-ZB-SW01.png" src="../_images/node_eWeLink-ZB-SW01.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , ZLL-DimmableLigh</p>
@@ -644,9 +644,9 @@
 <p>, , ZLO-OccupancySensor for Dev</p>
 <a class="reference internal image-reference" href="../_images/node_ZLO-OccupancySensor.png"><img alt="../_images/node_ZLO-OccupancySensor.png" src="../_images/node_ZLO-OccupancySensor.png" style="width: 200px;" /></a>
 <p>LiXee, ZLinky_TIC, LiXee Zlinky TIC module</p>
-<a class="reference internal image-reference" href="devices/images/node_Linky.png"><img alt="devices/images/node_Linky.png" src="devices/images/node_Linky.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Linky.png"><img alt="../_images/node_Linky.png" src="../_images/node_Linky.png" style="width: 200px;" /></a>
 <p>Xiaomi Aqara, AAQS-S01, Aqara AAQS-S01 TVOC air quality monitor</p>
-<a class="reference internal image-reference" href="devices/images/node_XiaomiAqara-AAQS-S01.png"><img alt="devices/images/node_XiaomiAqara-AAQS-S01.png" src="devices/images/node_XiaomiAqara-AAQS-S01.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_XiaomiAqara-AAQS-S01.png"><img alt="../_images/node_XiaomiAqara-AAQS-S01.png" src="../_images/node_XiaomiAqara-AAQS-S01.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>, , Xiaomi Prise Murale Encastrée</p>
@@ -702,9 +702,9 @@
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Xiaomi, WRS-R02, Xiaomi Aqara WRS-R02 Wireless Remote Switch H1 Double Rocker</p>
-<a class="reference internal image-reference" href="devices/images/node_XiaomiAqara-WRS-R02.png"><img alt="devices/images/node_XiaomiAqara-WRS-R02.png" src="devices/images/node_XiaomiAqara-WRS-R02.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_XiaomiAqara-WRS-R02.png"><img alt="../_images/node_XiaomiAqara-WRS-R02.png" src="../_images/node_XiaomiAqara-WRS-R02.png" style="width: 200px;" /></a>
 <p>Xiaomi, WXCJKG13LM, Aqara Opple wireless switch 6 buttons</p>
-<a class="reference internal image-reference" href="devices/images/node_Aqara-Opple-6buttons.png"><img alt="devices/images/node_Aqara-Opple-6buttons.png" src="devices/images/node_Aqara-Opple-6buttons.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Aqara-Opple-6buttons.png"><img alt="../_images/node_Aqara-Opple-6buttons.png" src="../_images/node_Aqara-Opple-6buttons.png" style="width: 200px;" /></a>
 <p>, , Virtual remote for groups control</p>
 <a class="reference internal image-reference" href="../_images/node_remotecontrol.png"><img alt="../_images/node_remotecontrol.png" src="../_images/node_remotecontrol.png" style="width: 200px;" /></a>
 <p>, , router</p>
@@ -754,21 +754,21 @@
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Xiaomi, SSM-U02, Xiaomi Single Switch Module T1 (No Neutral)</p>
-<a class="reference internal image-reference" href="devices/images/node_XiaomiAqara-SSM-U02.png"><img alt="devices/images/node_XiaomiAqara-SSM-U02.png" src="devices/images/node_XiaomiAqara-SSM-U02.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_XiaomiAqara-SSM-U02.png"><img alt="../_images/node_XiaomiAqara-SSM-U02.png" src="../_images/node_XiaomiAqara-SSM-U02.png" style="width: 200px;" /></a>
 <p>Xiaomi, WS-EUK01, Aqara H1 smart wall switch</p>
 <a class="reference internal image-reference" href="../_images/node_XiaomiPrise.png"><img alt="../_images/node_XiaomiPrise.png" src="../_images/node_XiaomiPrise.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Xiaomi, WS-EUK02, Aqara H1 WS-EUK02 smart wall switch</p>
-<a class="reference internal image-reference" href="devices/images/node_Aqara-WallSwitchH1-Double.png"><img alt="devices/images/node_Aqara-WallSwitchH1-Double.png" src="devices/images/node_Aqara-WallSwitchH1-Double.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_Aqara-WallSwitchH1-Double.png"><img alt="../_images/node_Aqara-WallSwitchH1-Double.png" src="../_images/node_Aqara-WallSwitchH1-Double.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Xiaomi, SSM-U01, Xiaomi Single Switch Module T1 (With Neutral)</p>
-<a class="reference internal image-reference" href="devices/images/node_XiaomiAqara-SSM-U01.png"><img alt="devices/images/node_XiaomiAqara-SSM-U01.png" src="devices/images/node_XiaomiAqara-SSM-U01.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_XiaomiAqara-SSM-U01.png"><img alt="../_images/node_XiaomiAqara-SSM-U01.png" src="../_images/node_XiaomiAqara-SSM-U01.png" style="width: 200px;" /></a>
 <p>, ,</p>
 <a class="reference internal image-reference" href="../_images/node_.png"><img alt="../_images/node_.png" src="../_images/node_.png" style="width: 200px;" /></a>
 <p>Xiaomi Aqara, , Xiaomi QBKG26LM 3 gang smart wall switch</p>
-<a class="reference internal image-reference" href="devices/images/node_XiaomiAqara-QBKG26LM.png"><img alt="devices/images/node_XiaomiAqara-QBKG26LM.png" src="devices/images/node_XiaomiAqara-QBKG26LM.png" style="width: 200px;" /></a>
+<a class="reference internal image-reference" href="../_images/node_XiaomiAqara-QBKG26LM.png"><img alt="../_images/node_XiaomiAqara-QBKG26LM.png" src="../_images/node_XiaomiAqara-QBKG26LM.png" style="width: 200px;" /></a>
 <p>, , Xiaomi Vibration</p>
 <a class="reference internal image-reference" href="../_images/node_XiaomiVibration.png"><img alt="../_images/node_XiaomiVibration.png" src="../_images/node_XiaomiVibration.png" style="width: 200px;" /></a>
 <p>, ,</p>

--- a/docs/devices/Danfoss.html
+++ b/docs/devices/Danfoss.html
@@ -17,15 +17,15 @@
     <link rel="search" title="Recherche" href="../search.html" />
     <link rel="next" title="Do It Yourself" href="../DIY.html" />
     <link rel="prev" title="Eurotronics" href="Eurotronics.html" />
-   
+
   <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
             <p class="logo"><a href="../index.html">
@@ -109,15 +109,15 @@
       </div>
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <div class="section" id="danfoss">
 <h1>Danfoss<a class="headerlink" href="#danfoss" title="Lien permanent vers ce titre">¶</a></h1>
 <div class="section" id="ally-tete-radiateur">
 <h2>Ally: Tete Radiateur<a class="headerlink" href="#ally-tete-radiateur" title="Lien permanent vers ce titre">¶</a></h2>
-<img alt="devices/images/Capture_d_ecran_2019_07_06_a_09_17_19.png" src="devices/images/Capture_d_ecran_2019_07_06_a_09_17_19.png" />
+<img alt="../_images/Capture_d_ecran_2019_07_06_a_09_17_19.png" src="../_images/Capture_d_ecran_2019_07_06_a_09_17_19.png" />
 <div class="section" id="premiere-mise-sous-tension">
 <h3>Premiere mise sous tension<a class="headerlink" href="#premiere-mise-sous-tension" title="Lien permanent vers ce titre">¶</a></h3>
 <ul class="simple">
@@ -168,7 +168,7 @@
 
 
           </div>
-          
+
         </div>
       </div>
     <div class="clearer"></div>
@@ -176,15 +176,15 @@
 
     <div class="footer">
       &copy;2019-22, KiwiHC16.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 4.1.2</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/docs/devices/Eurotronics.html
+++ b/docs/devices/Eurotronics.html
@@ -168,7 +168,7 @@ Affiche l’écran LCD « InS », l’assemblage peut être effectué. Continu
 <div class="section" id="homebridge">
 <h3>Homebridge<a class="headerlink" href="#homebridge" title="Lien permanent vers ce titre">¶</a></h3>
 <p>Voici la configuration qui fonctionne sur mon système:</p>
-<img alt="devices/images/Capture_d_ecran_2019_04_13_a_22_22-22.png" src="devices/images/Capture_d_ecran_2019_04_13_a_22_22-22.png" />
+<img alt="../_images/Capture_d_ecran_2019_04_13_a_22_22-22.png" src="../_images/Capture_d_ecran_2019_04_13_a_22_22-22.png" />
 </div>
 </div>
 </div>

--- a/docs/devices/Heiman.html
+++ b/docs/devices/Heiman.html
@@ -17,15 +17,15 @@
     <link rel="search" title="Recherche" href="../search.html" />
     <link rel="next" title="Ikea" href="Ikea.html" />
     <link rel="prev" title="Do It Yourself" href="../DIY.html" />
-   
+
   <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
             <p class="logo"><a href="../index.html">
@@ -109,10 +109,10 @@
       </div>
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <div class="section" id="heiman">
 <h1>Heiman<a class="headerlink" href="#heiman" title="Lien permanent vers ce titre">¶</a></h1>
 <div class="section" id="detecteur-de-fumee">
@@ -121,7 +121,7 @@
 = = = = =</p>
 <p>ZiGate en mode Inclusion
 Trombone dans petit trou sur le côté pendant 4s, le device fait un Beacon, flash en vert en face avant, s’appaire et est créé dans Abeille.</p>
-<img alt="devices/images/Capture_d_ecran_2019_07_06_a_11_40_01.png" src="devices/images/Capture_d_ecran_2019_07_06_a_11_40_01.png" />
+<img alt="../_images/Capture_d_ecran_2019_07_06_a_11_40_01.png" src="../_images/Capture_d_ecran_2019_07_06_a_11_40_01.png" />
 <p>Exclusion
 = = = = =</p>
 <p>Trombone dans petit trou sur le côté pendant 8s, le device fait un Leave. Bouton face avant flash plusieurs fois en vert.</p>
@@ -136,7 +136,7 @@ Trombone dans petit trou sur le côté pendant 4s, le device fait un Beacon, fla
 <p>L’information brute remonte dans Abeille. Par défaut sans alarme la valeur est à 20. Avec alarme l’information est à 21.</p>
 <p>Un appui sur le bouton de la face avant provoque une alarme (un message remonte) et lors de la relache un autre message est envoyé pour indiquer fin d’alarme.</p>
 <p>Vous pouvez décoder les informations remontant sur la base de :</p>
-<img alt="devices/images/Capture_d_ecran_2019_07_09_a_15_51_27.png" src="devices/images/Capture_d_ecran_2019_07_09_a_15_51_27.png" />
+<img alt="../_images/Capture_d_ecran_2019_07_09_a_15_51_27.png" src="../_images/Capture_d_ecran_2019_07_09_a_15_51_27.png" />
 <div class="admonition note">
 <p class="admonition-title">Note</p>
 <p>Pour tester, prendre un briquet, l’allumer et le placer sous le capteur. Le capteur active son alarme, attention aux oreilles, et le champ passe à 21 dans Abeille.</p>
@@ -146,7 +146,7 @@ Trombone dans petit trou sur le côté pendant 4s, le device fait un Beacon, fla
 
 
           </div>
-          
+
         </div>
       </div>
     <div class="clearer"></div>
@@ -154,15 +154,15 @@ Trombone dans petit trou sur le côté pendant 4s, le device fait un Beacon, fla
 
     <div class="footer">
       &copy;2019-22, KiwiHC16.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 4.1.2</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/docs/devices/Ikea.html
+++ b/docs/devices/Ikea.html
@@ -17,15 +17,15 @@
     <link rel="search" title="Recherche" href="../search.html" />
     <link rel="next" title="Innr" href="Innr.html" />
     <link rel="prev" title="Heiman" href="Heiman.html" />
-   
+
   <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
             <p class="logo"><a href="../index.html">
@@ -118,10 +118,10 @@
       </div>
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <div class="section" id="ikea">
 <h1>Ikea<a class="headerlink" href="#ikea" title="Lien permanent vers ce titre">¶</a></h1>
 <div class="section" id="ampoule">
@@ -155,7 +155,7 @@ Boucle qui fait 6 fois : OFF / sleep 2s / ON / sleep 0.5s .</p>
 <p>Ce bouton est créé au moment de la création de l’objet. Celui ci permet de demander à l’ampoule de se manifester. Elle se met à changer d’intensité ce qui nous permet de la repérer dans une groupe d’ampoules par exemple.</p>
 <p><strong>Bind</strong></p>
 <p>Identifiez l’ampoule que vous voulez paramétrer:</p>
-<img alt="devices/images/Capture_d_ecran_2018-02_21_a_23_26_56.png" src="devices/images/Capture_d_ecran_2018-02_21_a_23_26_56.png" />
+<img alt="../_images/Capture_d_ecran_2018-02_21_a_23_26_56.png" src="../_images/Capture_d_ecran_2018-02_21_a_23_26_56.png" />
 <p>Récupérer son adresse IEEE, son adresse courte (ici 6766).</p>
 <p>De même, dans l’objet Ruche récupérez l’adresse IEEE (Si l’info n’est pas dispo, un reset de la Zigate depuis l objet ruche doit faire remonter l’information).</p>
 <p>Mettre dans le champ:</p>
@@ -174,7 +174,7 @@ Boucle qui fait 6 fois : OFF / sleep 2s / ON / sleep 0.5s .</p>
 </pre></div>
 </div>
 <p>Après clic sur Bind, vous devriez voir passer dans le log AbeilleParser (en mode debug) un message comme:</p>
-<img alt="devices/images/Capture_d_ecran_2018_02_21_a_23_27_29.png" src="devices/images/Capture_d_ecran_2018_02_21_a_23_27_29.png" />
+<img alt="../_images/Capture_d_ecran_2018_02_21_a_23_27_29.png" src="../_images/Capture_d_ecran_2018_02_21_a_23_27_29.png" />
 <p>qui confirme la prise en compte par l’ampoule. Status 00 si Ok.</p>
 <p><strong>Rapport Manuel</strong></p>
 <p>Ensuite paramétrer l’envoie de rapport:</p>
@@ -182,7 +182,7 @@ Boucle qui fait 6 fois : OFF / sleep 2s / ON / sleep 0.5s .</p>
 <li><p>Titre, l’adresse courte de l’ampoule</p></li>
 <li><p>Message, le cluster et le paramètre dans le cluster</p></li>
 </ul>
-<img alt="devices/images/Capture_d_ecran_2018_02_21_a_23_29_11.png" src="devices/images/Capture_d_ecran_2018_02_21_a_23_29_11.png" />
+<img alt="../_images/Capture_d_ecran_2018_02_21_a_23_29_11.png" src="../_images/Capture_d_ecran_2018_02_21_a_23_29_11.png" />
 <p>Attention a capture d’écran n’est pas à jour pour le deuxième champs.:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">targetEndpoint</span><span class="o">=</span><span class="mi">01</span><span class="o">&amp;</span><span class="n">ClusterId</span><span class="o">=</span><span class="mi">0006</span><span class="o">&amp;</span><span class="n">AttributeType</span><span class="o">=</span><span class="mi">10</span><span class="o">&amp;</span><span class="n">AttributeId</span><span class="o">=</span><span class="mi">0000</span> <span class="n">pour</span> <span class="n">retour</span> <span class="n">d</span><span class="s1">&#39;état ampoule Ikea</span>
 <span class="n">targetEndpoint</span><span class="o">=</span><span class="mi">01</span><span class="o">&amp;</span><span class="n">ClusterId</span><span class="o">=</span><span class="mi">0008</span><span class="o">&amp;</span><span class="n">AttributeType</span><span class="o">=</span><span class="mi">20</span><span class="o">&amp;</span><span class="n">AttributeId</span><span class="o">=</span><span class="mi">0000</span> <span class="n">pour</span> <span class="n">retour</span> <span class="n">de</span> <span class="n">niveau</span> <span class="n">ampoule</span> <span class="n">Ikea</span>
@@ -191,10 +191,10 @@ Boucle qui fait 6 fois : OFF / sleep 2s / ON / sleep 0.5s .</p>
 <p>De même vous devriez voir passer dans le log AbeilleParse (en mode debug) un message comme:</p>
 <p>qui confirme la prise en compte par l’ampoule. Status 00 si Ok.</p>
 <p>Après sur un changement d’état l’ampoule doit remonter l’info vers Abeille, avec des messages comme:</p>
-<img alt="devices/images/Capture_d_ecran_2018_02_21_a_23_31_11.png" src="devices/images/Capture_d_ecran_2018_02_21_a_23_31_11.png" />
+<img alt="../_images/Capture_d_ecran_2018_02_21_a_23_31_11.png" src="../_images/Capture_d_ecran_2018_02_21_a_23_31_11.png" />
 <p>pour un retour Off de l’ampoule.</p>
 <p><strong>HomeBridge</strong></p>
-<img alt="devices/images/Capture_d_ecran_2019_04_14_a_00_44_29.png" src="devices/images/Capture_d_ecran_2019_04_14_a_00_44_29.png" />
+<img alt="../_images/Capture_d_ecran_2019_04_14_a_00_44_29.png" src="../_images/Capture_d_ecran_2019_04_14_a_00_44_29.png" />
 </div>
 <div class="section" id="telecommande-ronde-5-boutons">
 <span id="telecommanderonde5boutons"></span><h2>Télécommande Ronde 5 boutons<a class="headerlink" href="#telecommande-ronde-5-boutons" title="Lien permanent vers ce titre">¶</a></h2>
@@ -227,19 +227,19 @@ Boucle qui fait 6 fois : OFF / sleep 2s / ON / sleep 0.5s .</p>
 </div>
 <p>Il faut connaitre l’adresse de la télécommande.</p>
 <p>Puis dans la ruche demander son nom. Par exemple pour la télécommande à l’adresse ec15</p>
-<img alt="devices/images/Capture_d_ecran_2018_02_28_a_13_59_31.png" src="devices/images/Capture_d_ecran_2018_02_28_a_13_59_31.png" />
+<img alt="../_images/Capture_d_ecran_2018_02_28_a_13_59_31.png" src="../_images/Capture_d_ecran_2018_02_28_a_13_59_31.png" />
 <p>et immédiatement après appuyez sur un des boutons de la télécommande pour la réveiller (pas sur le bouton arrière).</p>
 <p>Et après un rafraichissement de l’écran vous devez avoir un objet</p>
-<img alt="devices/images/Capture_d_ecran_2018_02_28_a_14_00_58.png" src="devices/images/Capture_d_ecran_2018_02_28_a_14_00_58.png" />
+<img alt="../_images/Capture_d_ecran_2018_02_28_a_14_00_58.png" src="../_images/Capture_d_ecran_2018_02_28_a_14_00_58.png" />
 <p>Il faut ensuite éditer les commandes en remplaçant l’adresse de la télécommande par le groupe que l’on veut contrôler</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
 <p>Il n’est plus nécessaire de faire la modification dans les commandes mais mettre l’Id du groupe dans les parametres.</p>
 </div>
 <p>La configuration</p>
-<img alt="devices/images/Capture_d_ecran_2018_02_28_a_14_03_26.png" src="devices/images/Capture_d_ecran_2018_02_28_a_14_03_26.png" />
+<img alt="../_images/Capture_d_ecran_2018_02_28_a_14_03_26.png" src="../_images/Capture_d_ecran_2018_02_28_a_14_03_26.png" />
 <p>va devenir</p>
-<img alt="devices/images/Capture_d_ecran_2018_02_28_a_14_03_47.png" src="devices/images/Capture_d_ecran_2018_02_28_a_14_03_47.png" />
+<img alt="../_images/Capture_d_ecran_2018_02_28_a_14_03_47.png" src="../_images/Capture_d_ecran_2018_02_28_a_14_03_47.png" />
 <p>pour le groupe 5FBD.</p>
 <p><strong>Leave</strong></p>
 <ul class="simple">
@@ -254,7 +254,7 @@ Boucle qui fait 6 fois : OFF / sleep 2s / ON / sleep 0.5s .</p>
 <p>Pour ce faire, il faut utiliser la commande « Set Group Remote » et réveiller la télécommande. En gros la tetecommande étant sur pile, elle dort pour ne pas consommer de courant et ne peut pas entendre les demandes d’Abeille/ZiGate.
 Il faut donc la reveiller, pour cela un appui sur un de ses 5 boutons la reveille pendant quelques secondes. En fait, elle envoie l info d un bouton appuyé puis ecoute pendant quelques secondes et c est la qu on peut lui demander de prendre une configuration de groupe.
 Donc definir le group dans le champ Id, appui sur un bouton de la telecommande et « Set Group Remote ».</p>
-<img alt="devices/images/Capture_d_ecran_2019_07_02_a_15_12_26.png" src="devices/images/Capture_d_ecran_2019_07_02_a_15_12_26.png" />
+<img alt="../_images/Capture_d_ecran_2019_07_02_a_15_12_26.png" src="../_images/Capture_d_ecran_2019_07_02_a_15_12_26.png" />
 <div class="admonition attention">
 <p class="admonition-title">Attention</p>
 <p>« Set Group Remote » ne devrait fonctionner que pour les telecommande Ikea.</p>
@@ -272,14 +272,14 @@ Donc definir le group dans le champ Id, appui sur un bouton de la telecommande e
 <ul class="simple">
 <li><p>Ouvrir la page commande de la ruche et trouver la commande « TRADFRI remote control ».</p></li>
 </ul>
-<img alt="devices/images/Capture_d_ecran_2018_03_02_a_10_34_40.png" src="devices/images/Capture_d_ecran_2018_03_02_a_10_34_40.png" />
+<img alt="../_images/Capture_d_ecran_2018_03_02_a_10_34_40.png" src="../_images/Capture_d_ecran_2018_03_02_a_10_34_40.png" />
 <p>Remplacez « /TRADFRI remote control/ » l’adresse du groupe que vous voulez contrôler. Par exemple AAAA.</p>
-<img alt="devices/images/Capture_d_ecran_2018_03_02_a_10_35_08.png" src="devices/images/Capture_d_ecran_2018_03_02_a_10_35_08.png" />
+<img alt="../_images/Capture_d_ecran_2018_03_02_a_10_35_08.png" src="../_images/Capture_d_ecran_2018_03_02_a_10_35_08.png" />
 <p>Sauvegardez et faites « Tester ».</p>
 <p>Vous avez maintenant une télécommande pour contrôler le groupe AAAA.</p>
-<img alt="devices/images/Capture_d_ecran_2018_03_02_a_10_35_28.png" src="devices/images/Capture_d_ecran_2018_03_02_a_10_35_28.png" />
+<img alt="../_images/Capture_d_ecran_2018_03_02_a_10_35_28.png" src="../_images/Capture_d_ecran_2018_03_02_a_10_35_28.png" />
 <p>Ouvrez l’équipement « Abeille-AAAA » et ouvrez le tab « Parameter ».</p>
-<img alt="devices/images/Capture_d_ecran_2019_07_05_a_11_42_05.png" src="devices/images/Capture_d_ecran_2019_07_05_a_11_42_05.png" />
+<img alt="../_images/Capture_d_ecran_2019_07_05_a_11_42_05.png" src="../_images/Capture_d_ecran_2019_07_05_a_11_42_05.png" />
 <p>et définissez le groupe à controller dans le champ Groupe.</p>
 <p id="telecommande-ikea-recuperation"><strong>Récupération</strong></p>
 <p>Récupération des appuis Télécommande Ikea dans Abeille</p>
@@ -412,32 +412,32 @@ Par exemple vous pouvez avoir une Ampoule Ikea sur le groupe de la télécommand
 <h2>Télécommande<a class="headerlink" href="#telecommande" title="Lien permanent vers ce titre">¶</a></h2>
 <p id="telecommanderonde5boutonssimulation"><strong>Simuler la télécommande</strong></p>
 <p>Pour créer une Telecommande simulée, clic sur l icone Télécommande:</p>
-<img alt="devices/images/Capture_d_ecran_2019_07_06_a_09_54_26.png" src="devices/images/Capture_d_ecran_2019_07_06_a_09_54_26.png" />
+<img alt="../_images/Capture_d_ecran_2019_07_06_a_09_54_26.png" src="../_images/Capture_d_ecran_2019_07_06_a_09_54_26.png" />
 <p>apres rafraichissement de l’écran vous aurez une telecommande:</p>
-<img alt="devices/images/Capture_d_ecran_2019_07_06_a_09_55_32.png" src="devices/images/Capture_d_ecran_2019_07_06_a_09_55_32.png" />
+<img alt="../_images/Capture_d_ecran_2019_07_06_a_09_55_32.png" src="../_images/Capture_d_ecran_2019_07_06_a_09_55_32.png" />
 <p>Il suffit maintenant de mettre l’Id du groupe dans ses parametres.</p>
 <p><strong>Récupérer un groupe</strong></p>
 <p>Cette opération est un peu délicate mais doit permettre de récupérer l’adresse de groupe utilisée par la télécommande suite aux opérations ci dessus. Dans le futur ce devrait être automatique.</p>
 <p>Aller dans la page de configuration du plugin et clic sur « Network » pour faire apparaitre les paramètres dans l’Ampoule:</p>
-<img alt="devices/images/Capture_d_ecran_2018_10_30_a_11_30_24.png" src="devices/images/Capture_d_ecran_2018_10_30_a_11_30_24.png" />
+<img alt="../_images/Capture_d_ecran_2018_10_30_a_11_30_24.png" src="../_images/Capture_d_ecran_2018_10_30_a_11_30_24.png" />
 <p>Sur l’objet Ampoule vous devez vous le champ « Groups » apparaitre sans information:</p>
-<img alt="devices/images/Capture_d_ecran_2018_10_30_a_11_36_43.png" src="devices/images/Capture_d_ecran_2018_10_30_a_11_36_43.png" />
+<img alt="../_images/Capture_d_ecran_2018_10_30_a_11_36_43.png" src="../_images/Capture_d_ecran_2018_10_30_a_11_36_43.png" />
 <p>Recuperons l’adresse de l ampoule, en ouvrant la page de configuration de l ampoule:</p>
-<img alt="devices/images/Capture_d_ecran_2018_10_30_a_11_42_09.png" src="devices/images/Capture_d_ecran_2018_10_30_a_11_42_09.png" />
+<img alt="../_images/Capture_d_ecran_2018_10_30_a_11_42_09.png" src="../_images/Capture_d_ecran_2018_10_30_a_11_42_09.png" />
 <p>Le champ « Topic Abeille » contient l’adresse, ici « 9252 ».</p>
 <p>Interrogeons maintenant l’ampoule, avec un getGroupMemberShip depuis l objet Ruche:</p>
-<img alt="devices/images/Capture_d_ecran_2018_10_30_a_11_45_23.png" src="devices/images/Capture_d_ecran_2018_10_30_a_11_45_23.png" />
+<img alt="../_images/Capture_d_ecran_2018_10_30_a_11_45_23.png" src="../_images/Capture_d_ecran_2018_10_30_a_11_45_23.png" />
 <p>Indiquez l’adresse de l ampoule.</p>
 <p>Maintenant le champ « Groups » de l’ampoule doit contenir l’adresse de groupe:</p>
-<img alt="devices/images/Capture_d_ecran_2018_10_30_a_11_47_24.png" src="devices/images/Capture_d_ecran_2018_10_30_a_11_47_24.png" />
+<img alt="../_images/Capture_d_ecran_2018_10_30_a_11_47_24.png" src="../_images/Capture_d_ecran_2018_10_30_a_11_47_24.png" />
 <p>ici le groupe utilisé par la télécommande est « f65d ».</p>
 <p>Maintenant nous pouvons mettre à jour la télécommande dans Jeedom. Ouvrez les commandes de la télécommande:</p>
-<img alt="devices/images/Capture_d_ecran_2018_10_30_a_11_50_17.png" src="devices/images/Capture_d_ecran_2018_10_30_a_11_50_17.png" />
+<img alt="../_images/Capture_d_ecran_2018_10_30_a_11_50_17.png" src="../_images/Capture_d_ecran_2018_10_30_a_11_50_17.png" />
 <p>Dans le champ « Topic » des commandes vous pouvez voir le texte =addrGroup= qu’il faut remplacer par la valeur du groupe, ici « f65d » et sauvegarder.</p>
 <p>Cela donne:</p>
-<img alt="devices/images/Capture_d_ecran_2018_10_30_a_11_54_51.png" src="devices/images/Capture_d_ecran_2018_10_30_a_11_54_51.png" />
+<img alt="../_images/Capture_d_ecran_2018_10_30_a_11_54_51.png" src="../_images/Capture_d_ecran_2018_10_30_a_11_54_51.png" />
 <p>Maintenant vous pouvez commander votre ampoule depuis la Télécommande physique et depuis la Télécommande Jeedom.</p>
-<img alt="devices/images/Capture_d_ecran_2018_10_30_a_11_58_42.png" src="devices/images/Capture_d_ecran_2018_10_30_a_11_58_42.png" />
+<img alt="../_images/Capture_d_ecran_2018_10_30_a_11_58_42.png" src="../_images/Capture_d_ecran_2018_10_30_a_11_58_42.png" />
 <p>PS: Les scénarios ne sont pas implémentés pour l’instant (30/10/2018):</p>
 <ul class="simple">
 <li><p>Sc1, Sc2, SC3 sur la télécommande dans Jeedom,</p></li>
@@ -499,7 +499,7 @@ declencher le capteur en bougeant devant lui et l ampoule doit s allumer.</p>
 
 
           </div>
-          
+
         </div>
       </div>
     <div class="clearer"></div>
@@ -507,15 +507,15 @@ declencher le capteur en bougeant devant lui et l ampoule doit s allumer.</p>
 
     <div class="footer">
       &copy;2019-22, KiwiHC16.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 4.1.2</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/docs/devices/Konke.html
+++ b/docs/devices/Konke.html
@@ -17,15 +17,15 @@
     <link rel="search" title="Recherche" href="../search.html" />
     <link rel="next" title="Legrand" href="Legrand.html" />
     <link rel="prev" title="Innr" href="Innr.html" />
-   
+
   <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
             <p class="logo"><a href="../index.html">
@@ -112,10 +112,10 @@
       </div>
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <div class="section" id="konke">
 <h1>Konke<a class="headerlink" href="#konke" title="Lien permanent vers ce titre">¶</a></h1>
 <p><a class="reference external" href="https://faire-ca-soi-meme.fr/domotique/2019/07/16/test-du-kit-zigbee-konke-smart-home/">https://faire-ca-soi-meme.fr/domotique/2019/07/16/test-du-kit-zigbee-konke-smart-home/</a></p>
@@ -199,8 +199,8 @@
 <li><p>cd: si alarme</p></li>
 <li><p>1: si pas alarme</p></li>
 </ul>
-<img alt="devices/images/Capture_d_ecran_2019_08_01_a_16_32_55.png" src="devices/images/Capture_d_ecran_2019_08_01_a_16_32_55.png" />
-<img alt="devices/images/Capture_d_ecran_2019_08_01_a_16_32-39.png" src="devices/images/Capture_d_ecran_2019_08_01_a_16_32-39.png" />
+<img alt="../_images/Capture_d_ecran_2019_08_01_a_16_32_55.png" src="../_images/Capture_d_ecran_2019_08_01_a_16_32_55.png" />
+<img alt="../_images/Capture_d_ecran_2019_08_01_a_16_32-39.png" src="../_images/Capture_d_ecran_2019_08_01_a_16_32-39.png" />
 <ul class="simple">
 <li><p>Volt Batterie, ne semble pas remonter à vérifier.</p></li>
 </ul>
@@ -210,7 +210,7 @@
 
 
           </div>
-          
+
         </div>
       </div>
     <div class="clearer"></div>
@@ -218,15 +218,15 @@
 
     <div class="footer">
       &copy;2019-22, KiwiHC16.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 4.1.2</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/docs/devices/Legrand.html
+++ b/docs/devices/Legrand.html
@@ -17,15 +17,15 @@
     <link rel="search" title="Recherche" href="../search.html" />
     <link rel="next" title="Livolo" href="Livolo.html" />
     <link rel="prev" title="Konke" href="Konke.html" />
-   
+
   <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
             <p class="logo"><a href="../index.html">
@@ -114,10 +114,10 @@
       </div>
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <div class="section" id="legrand">
 <h1>Legrand<a class="headerlink" href="#legrand" title="Lien permanent vers ce titre">¶</a></h1>
 <div class="section" id="contacteur-20ax">
@@ -126,7 +126,7 @@
 </div>
 <div class="section" id="prise-220v">
 <h2>Prise 220V<a class="headerlink" href="#prise-220v" title="Lien permanent vers ce titre">¶</a></h2>
-<img alt="devices/images/Capture_d_ecran_2019_07_06_a_09_17_19.png" src="devices/images/Capture_d_ecran_2019_07_06_a_09_17_19.png" />
+<img alt="../_images/Capture_d_ecran_2019_07_06_a_09_17_19.png" src="../_images/Capture_d_ecran_2019_07_06_a_09_17_19.png" />
 <p><strong>Fonctions</strong></p>
 <dl class="simple">
 <dt>Fonctionne:</dt><dd><ul class="simple">
@@ -171,7 +171,7 @@ Si deja associé, faire un reset bouton proche roue crantée sur le Bouton au fo
 </div>
 <div class="section" id="module-encastre">
 <h2>Module Encastré<a class="headerlink" href="#module-encastre" title="Lien permanent vers ce titre">¶</a></h2>
-<img alt="devices/images/Capture_d_ecran_2019_07_06_a_13_29_06.png" src="devices/images/Capture_d_ecran_2019_07_06_a_13_29_06.png" />
+<img alt="../_images/Capture_d_ecran_2019_07_06_a_13_29_06.png" src="../_images/Capture_d_ecran_2019_07_06_a_13_29_06.png" />
 <p><strong>Spécifications</strong></p>
 <p>Module On/Off
 1.3A max
@@ -331,7 +331,7 @@ Si Elle est On elle semble accepter les level mais va du max au min (et vis vers
 
 
           </div>
-          
+
         </div>
       </div>
     <div class="clearer"></div>
@@ -339,15 +339,15 @@ Si Elle est On elle semble accepter les level mais va du max au min (et vis vers
 
     <div class="footer">
       &copy;2019-22, KiwiHC16.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 4.1.2</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/docs/devices/OSRAM.html
+++ b/docs/devices/OSRAM.html
@@ -17,15 +17,15 @@
     <link rel="search" title="Recherche" href="../search.html" />
     <link rel="next" title="Philips Hue" href="PhilipsHue.html" />
     <link rel="prev" title="Livolo" href="Livolo.html" />
-   
+
   <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
             <p class="logo"><a href="../index.html">
@@ -113,10 +113,10 @@
       </div>
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <div class="section" id="osram">
 <h1>OSRAM<a class="headerlink" href="#osram" title="Lien permanent vers ce titre">¶</a></h1>
 <div class="section" id="prise-smart">
@@ -127,7 +127,7 @@
 <li><p>Mettre la Zigate en mode inclusion (Bouton Inclusion), la Led bleue de la Zigate doit clignoter…</p></li>
 <li><p>Appui long sur le bouton du flanc de la prise, la prise switche rapidement On/Off, lâcher le bouton, l’équipement doit se connecter et un objet doit apparaître dans Jeedom.</p></li>
 </ul>
-<img alt="devices/images/plug01_new.png" src="devices/images/plug01_new.png" />
+<img alt="../_images/plug01_new.png" src="../_images/plug01_new.png" />
 <p><strong>Inclue</strong></p>
 <p>Déjà inclue préalablement</p>
 <ul class="simple">
@@ -140,7 +140,7 @@
 - et sur l’objet ruche</p>
 <p>Si ce n’est pas le cas vous pouvez faire un « liste Equipements » sur la ruche. Si cela ne suffit pas il faut faire « menu-&gt;Plugins-&gt;Protocol domotique-&gt;Abeille-&gt;Network List-&gt;Table de noeuds-&gt;Recalcul du cache » (Soyez patient).</p>
 <p>Ensuite utilisez de préférence « BindShortToZigateEtat » puis « setReportEtat ». Maintenant un changement d’état doit remonter tout seul et mettre à jour l’icone.</p>
-<img alt="devices/images/Capture_d_ecran_2018_06_27_a_11_24_09.png" src="devices/images/Capture_d_ecran_2018_06_27_a_11_24_09.png" />
+<img alt="../_images/Capture_d_ecran_2018_06_27_a_11_24_09.png" src="../_images/Capture_d_ecran_2018_06_27_a_11_24_09.png" />
 <p>Le retour d’état ne remonte que si l’état change. Donc si l’icone n’est pas synchro avec la prise vous pouvez avoir l’impression que cela ne fonctionne pas. Ex: la prise est Off et l’icone est on. Vous faites Off et rien ne se passe. Pour éviter cela un double Toggle doit réaligner tout le monde.</p>
 <p>——————————————————- A clarifier</p>
 <p><strong>Remove</strong></p>
@@ -201,7 +201,7 @@ Pile: CR2</p>
 
 
           </div>
-          
+
         </div>
       </div>
     <div class="clearer"></div>
@@ -209,15 +209,15 @@ Pile: CR2</p>
 
     <div class="footer">
       &copy;2019-22, KiwiHC16.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 4.1.2</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/docs/devices/PhilipsHue.html
+++ b/docs/devices/PhilipsHue.html
@@ -17,15 +17,15 @@
     <link rel="search" title="Recherche" href="../search.html" />
     <link rel="next" title="Profalux" href="Profalux.html" />
     <link rel="prev" title="OSRAM" href="OSRAM.html" />
-   
+
   <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
             <p class="logo"><a href="../index.html">
@@ -115,10 +115,10 @@
       </div>
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <div class="section" id="philips-hue">
 <h1>Philips Hue<a class="headerlink" href="#philips-hue" title="Lien permanent vers ce titre">¶</a></h1>
 <div class="section" id="ampoule-1">
@@ -264,7 +264,7 @@ Voir aussi <a class="reference external" href="https://en.wikipedia.org/wiki/Lux
 <p><strong>Batterie</strong></p>
 <p>(A tester)</p>
 <p><strong>Homebridge</strong></p>
-<img alt="devices/images/Capture_d_ecran_2019_04_14_a_00_44_30.png" src="devices/images/Capture_d_ecran_2019_04_14_a_00_44_30.png" />
+<img alt="../_images/Capture_d_ecran_2019_04_14_a_00_44_30.png" src="../_images/Capture_d_ecran_2019_04_14_a_00_44_30.png" />
 </div>
 <div class="section" id="motion-sensor-outdoor">
 <h2>Motion Sensor Outdoor<a class="headerlink" href="#motion-sensor-outdoor" title="Lien permanent vers ce titre">¶</a></h2>
@@ -274,7 +274,7 @@ Voir aussi <a class="reference external" href="https://en.wikipedia.org/wiki/Lux
 
 
           </div>
-          
+
         </div>
       </div>
     <div class="clearer"></div>
@@ -282,15 +282,15 @@ Voir aussi <a class="reference external" href="https://en.wikipedia.org/wiki/Lux
 
     <div class="footer">
       &copy;2019-22, KiwiHC16.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 4.1.2</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/docs/devices/Profalux.html
+++ b/docs/devices/Profalux.html
@@ -130,7 +130,7 @@
 <li><p>A l’aide d’un trombone, appuyer 5 fois sur le bouton R.</p></li>
 </ul>
 <p>La télécommande va clignoter rouge puis vert.</p>
-<img alt="devices/images/profalux_inclusion_etape1.png" src="devices/images/profalux_inclusion_etape1.png" />
+<img alt="../_images/profalux_inclusion_etape1.png" src="../_images/profalux_inclusion_etape1.png" />
 <p>Le volet va faire un va et vient (attendre un petit moment).</p>
 <p>Attendre que la télécommande ne clignote plus.</p>
 <ul class="simple">
@@ -171,23 +171,23 @@ Attendre que la télécommande ne clignote plus !</p>
 <li><p>Retourner l’appareil</p></li>
 <li><p>A l’aide d’un trombone, appuyer 5 fois sur le bouton R</p></li>
 </ul>
-<img alt="devices/images/profalux_inclusion_etape1.png" src="devices/images/profalux_inclusion_etape1.png" />
+<img alt="../_images/profalux_inclusion_etape1.png" src="../_images/profalux_inclusion_etape1.png" />
 <p>Attention c’est une manipulation dangereuse !</p>
 <ul class="simple">
 <li><p>Couper l’alimentation électrique</p></li>
 <li><p>Réunir les fils noir et marron puis les brancher sur la borne de phase</p></li>
 </ul>
-<img alt="devices/images/profalux_inclusion_reset_volet2.png" src="devices/images/profalux_inclusion_reset_volet2.png" />
+<img alt="../_images/profalux_inclusion_reset_volet2.png" src="../_images/profalux_inclusion_reset_volet2.png" />
 <ul class="simple">
 <li><p>Remettre l’alimentation électrique pendant 5 secondes. Le volet devrait faire un petit mouvement.</p></li>
 <li><p>Couper l’alimentation électrique</p></li>
 <li><p>Séparer les fils noir et marron. Brancher le fils marron sur la phase. Si votre fils noir était brancher avec le bleu aupparavant, rebrancher le avec le bleu sinon laisser le fils noir seul en pensant à l’isoler(capuchon noir)</p></li>
 </ul>
-<img alt="devices/images/profalux_inclusion_reset_volet3.png" src="devices/images/profalux_inclusion_reset_volet3.png" />
+<img alt="../_images/profalux_inclusion_reset_volet3.png" src="../_images/profalux_inclusion_reset_volet3.png" />
 <ul class="simple">
 <li><p>Remettre l’alimentation électrique et dans la minute appuyer sur le bouton STOP</p></li>
 </ul>
-<img alt="devices/images/profalux_inclusion_reset_volet4.png" src="devices/images/profalux_inclusion_reset_volet4.png" />
+<img alt="../_images/profalux_inclusion_reset_volet4.png" src="../_images/profalux_inclusion_reset_volet4.png" />
 <p>Le volet devrait faire des mouvement de va-et-vient puis s’arrêter
 * La télécommande devrait à nouveau fonctionner
 * Recommencer à nouveau la procédure d’inclusion</p>

--- a/docs/devices/SonOff.html
+++ b/docs/devices/SonOff.html
@@ -17,15 +17,15 @@
     <link rel="search" title="Recherche" href="../search.html" />
     <link rel="next" title="Tuya" href="Tuya.html" />
     <link rel="prev" title="Profalux" href="Profalux.html" />
-   
+
   <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
             <p class="logo"><a href="../index.html">
@@ -113,10 +113,10 @@
       </div>
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <div class="section" id="sonoff">
 <h1>SonOff<a class="headerlink" href="#sonoff" title="Lien permanent vers ce titre">¶</a></h1>
 <div class="section" id="sonoff-snzb-01-interrupteur">
@@ -197,21 +197,21 @@
 <h2>SonOff BASICZBR3: Module 10A<a class="headerlink" href="#sonoff-basiczbr3-module-10a" title="Lien permanent vers ce titre">¶</a></h2>
 <p>Comme je ne trouvais pas de relai piloté par zigbee j’ai fait ma propre bidouille. Comme d’habitude comme c’est sur le 220V, je ne suis pas responsable de vos actes. Vous faites ces manipulations que si vous savez ce que vous faites. Je ne pourrai être tenu responsable.</p>
 <p>Vue d’ensemble du boitié:</p>
-<img alt="devices/images/IMG_2369.jpg" src="devices/images/IMG_2369.jpg" />
+<img alt="../_images/IMG_2369.jpg" src="../_images/IMG_2369.jpg" />
 <p>Il faut ouvrir la bête, le relai est le boitier noir vers le haut de la photo:</p>
-<img alt="devices/images/IMG_2370.jpg" src="devices/images/IMG_2370.jpg" />
+<img alt="../_images/IMG_2370.jpg" src="../_images/IMG_2370.jpg" />
 <p>On peut voir les pistes épaisses sous le dessous, allant sur les pattes du relai:</p>
-<img alt="devices/images/IMG_2371.jpg" src="devices/images/IMG_2371.jpg" />
+<img alt="../_images/IMG_2371.jpg" src="../_images/IMG_2371.jpg" />
 <p>Le relai lui même en 10A:</p>
-<img alt="devices/images/IMG_2372.jpg" src="devices/images/IMG_2372.jpg" />
+<img alt="../_images/IMG_2372.jpg" src="../_images/IMG_2372.jpg" />
 <p>Les deux grosses pistes qu’il va falloir couper:</p>
-<img alt="devices/images/IMG_2373.jpg" src="devices/images/IMG_2373.jpg" />
+<img alt="../_images/IMG_2373.jpg" src="../_images/IMG_2373.jpg" />
 <p>Au cuteur, découpe des deux pistes:</p>
-<img alt="devices/images/IMG_2375.jpg" src="devices/images/IMG_2375.jpg" />
+<img alt="../_images/IMG_2375.jpg" src="../_images/IMG_2375.jpg" />
 <p>Mais en faite cela ne suffit pas il faut prendre la perceuse et passer au travers completement:</p>
-<img alt="devices/images/IMG_2376.jpg" src="devices/images/IMG_2376.jpg" />
+<img alt="../_images/IMG_2376.jpg" src="../_images/IMG_2376.jpg" />
 <p>Souder un bout de cuivre entre la patte du relai et la piste extérieure:</p>
-<img alt="devices/images/IMG_2377.jpg" src="devices/images/IMG_2377.jpg" />
+<img alt="../_images/IMG_2377.jpg" src="../_images/IMG_2377.jpg" />
 <p>Et le tour est joué.</p>
 <p>Note: lors du retablissement du courant, suite à une coupure de secteur par exemple, le module se souvient de son état initial et reposition le relai dans cet état.</p>
 </div>
@@ -219,7 +219,7 @@
 
 
           </div>
-          
+
         </div>
       </div>
     <div class="clearer"></div>
@@ -227,15 +227,15 @@
 
     <div class="footer">
       &copy;2019-22, KiwiHC16.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 4.1.2</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/docs/devices/Xiaomi.html
+++ b/docs/devices/Xiaomi.html
@@ -17,15 +17,15 @@
     <link rel="search" title="Recherche" href="../search.html" />
     <link rel="next" title="Installation" href="../Installation.html" />
     <link rel="prev" title="Tuya" href="Tuya.html" />
-   
+
   <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
   <div class="document">
-    
+
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
         <div class="sphinxsidebarwrapper">
             <p class="logo"><a href="../index.html">
@@ -124,10 +124,10 @@
       </div>
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <div class="section" id="xiaomi">
 <h1>Xiaomi<a class="headerlink" href="#xiaomi" title="Lien permanent vers ce titre">¶</a></h1>
 <div class="section" id="tous">
@@ -160,8 +160,8 @@
 <p>Par défaut le bouton est configuré pour déclencher les scénarii à chaque appui (même si l’état était déjà à 1). Mais Jeedom va aussi provoquer un événement au bout d’une minute en passant la valeur à 0.</p>
 <p>Lors de l’exécution du scénario, si vous testé l’état du bouton est qu’il est à un vous avez reçu un événement appui bouton, si l’état est 0, vous avez reçu un événement retour à zéro après une minute.</p>
 <p>Par exemple pour commander une ampoule Ikea:</p>
-<img alt="devices/images/Capture_d_ecran_2018_09_04_a_13_05_49.png" src="devices/images/Capture_d_ecran_2018_09_04_a_13_05_49.png" />
-<img alt="devices/images/Capture_d_ecran_2018_09_04_a_13_05_.36.png" src="devices/images/Capture_d_ecran_2018_09_04_a_13_05_.36.png" />
+<img alt="../_images/Capture_d_ecran_2018_09_04_a_13_05_49.png" src="../_images/Capture_d_ecran_2018_09_04_a_13_05_49.png" />
+<img alt="../_images/Capture_d_ecran_2018_09_04_a_13_05_.36.png" src="../_images/Capture_d_ecran_2018_09_04_a_13_05_.36.png" />
 <p>Multi</p>
 <p>Pour l’information multi, celle ci remonte quand on fait plus d’un appui sur le bouton. Multi prend alors la valeur remontée. Le bouton n’envoie pas d’autre information et donc la valeur reste indéfiniment. Par défaut l’objet créé demande à Jeedom de faire un retour d’état à 0 après une minute. Cela peut être enlevé dans les paramètres de la commande.</p>
 <p>Le fonctionnement de base va provoquer 2 événements, un lors de l’appui multiple, puis un second après 1 minute (généré par Jeedom pour le retour d’état). Si vous enlevez de la commande le retour d’état alors vous n’aurez que l’événement appui multiple.
@@ -280,7 +280,7 @@ Remonte ff01 (len 37)</p>
 </div>
 <div class="section" id="cube-aqara">
 <h2>Cube Aqara<a class="headerlink" href="#cube-aqara" title="Lien permanent vers ce titre">¶</a></h2>
-<img alt="devices/images/Capture_d_ecran_2018_06_12_a_22_00_03.png" src="devices/images/Capture_d_ecran_2018_06_12_a_22_00_03.png" />
+<img alt="../_images/Capture_d_ecran_2018_06_12_a_22_00_03.png" src="../_images/Capture_d_ecran_2018_06_12_a_22_00_03.png" />
 </div>
 <div class="section" id="wall-switch-1">
 <h2>Wall Switch 1<a class="headerlink" href="#wall-switch-1" title="Lien permanent vers ce titre">¶</a></h2>
@@ -445,7 +445,7 @@ Vu la position en bout de bras que je lui ai donné, le capteur détecte un chan
 
 
           </div>
-          
+
         </div>
       </div>
     <div class="clearer"></div>
@@ -453,15 +453,15 @@ Vu la position en bout de bras que je lui ai donné, le capteur détecte un chan
 
     <div class="footer">
       &copy;2019-22, KiwiHC16.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 4.1.2</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
     </div>
 
-    
 
-    
+
+
   </body>
 </html>


### PR DESCRIPTION
Many images are currently missing when you click on device names from https://kiwihc16.github.io/AbeilleDoc/Equipements.html

This PR should fix their path.

I tested these changes directly in my browser: did not try to really deploy them from source.